### PR TITLE
only return icon if it exists

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -213,6 +213,9 @@ func chartVersionAttributes(cid string, cv models.ChartVersion) models.ChartVers
 func chartAttributes(c models.Chart) models.Chart {
 	if c.RawIcon != nil {
 		c.Icon = "/v1/assets/" + c.ID + "/logo-160x160-fit.png"
+	} else {
+		// If the icon wasn't processed, it is either not set or invalid
+		c.Icon = ""
 	}
 	return c
 }

--- a/handler.go
+++ b/handler.go
@@ -157,6 +157,11 @@ func getChartIcon(w http.ResponseWriter, req *http.Request, params Params) {
 		return
 	}
 
+	if chart.RawIcon == nil {
+		http.NotFound(w, req)
+		return
+	}
+
 	w.Write(chart.RawIcon)
 }
 
@@ -206,7 +211,9 @@ func chartVersionAttributes(cid string, cv models.ChartVersion) models.ChartVers
 }
 
 func chartAttributes(c models.Chart) models.Chart {
-	c.Icon = "/v1/assets/" + c.ID + "/logo-160x160-fit.png"
+	if c.RawIcon != nil {
+		c.Icon = "/v1/assets/" + c.ID + "/logo-160x160-fit.png"
+	}
 	return c
 }
 


### PR DESCRIPTION
We would previously return an empty 200 response for the icon asset request, and a link to the icon for charts that don't have icons